### PR TITLE
Change explainer example from `readAsBlob` to `blob`

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Here we use enumeration and new APIs on `FontMetadata` to access a full and vali
     if (metadata.postscriptName !== "Consolas")
       continue;
 
-    // 'readAsBlob()' returns a Blob containing valid and complete SFNT
+    // blob()' returns a Blob containing valid and complete SFNT
     // wrapped font data.
-    const sfnt = await metadata.readAsBlob();
+    const sfnt = await metadata.blob();
 
     const sfntVersion = (new TextDecoder).decode(
         // Slice out only the bytes we need: the first 4 bytes are the SFNT


### PR DESCRIPTION
We changed the method to `blob` as it is more inline to "modern" APIs.

This changes the example code for full font bytes.