### PR TITLE
Precision in explainer about fidelity for cross-platform apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Professional-quality design and graphics tools have historically been difficult 
 
 One stumbling block has been an inability to access and use the full variety of professionally constructed and hinted fonts which designers have locally installed. The web's answer to this situation has been the introduction of [Web Fonts](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Web_fonts) which are loaded dynamically by browsers and are subsequently available to use via CSS. This level of flexibility enables some publishing use-cases but fails to fully enable high-fidelity, platform independent vector-based design tools for several reasons:
 
- * System font engines (and browser stacks) may handle the parsing and display of certain glyphs differently. These differences are necessary, in general, to create fidelity with the underlying OS (so web content doesn't "look wrong"). These differences reduce fidelity.
+ * System font engines (and browser stacks) may handle the parsing and display of certain glyphs differently. These differences are necessary, in general, to create fidelity with the underlying OS (so web content doesn't "look wrong"). These differences reduce consistency for applications that span across multiple platforms, e.g. when pixel-accurate layout and rendering is required.
  * Developers may have legacy font stacks for their applications which they are bringing to the web. To use these engines, they usually require direct access to font data; something Web Fonts do not provide.
 
 We propose a two-part API to help address this gap:


### PR DESCRIPTION
In a sentence, the explainer mentioned that the platform differences were reducing fidelity without further qualification.

This change makes it clear that the reduction in fidelity occurs for cross-platform applications and not for the fonts themselves.
