### PR TITLE
Add a former editor section for Emil

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 > Last Update: September 1st, 2020
 >
 > Alex Russell `<slightlyoff@google.com>`<br>
-> Emil A Eklund `<eae@google.com>`<br>
 > Josh Bell `<jsbell@google.com>`<br>
 > Chase Phillips `<cmp@google.com>`<br>
 > Olivier Yiptong `<oyiptong@google.com>`<br>
@@ -260,6 +259,10 @@ To be of use, font table data must be consumed by a shaping engine such as [Harf
 
 ## References & acknowledgements
 
+Former editors:
+
+* Emil A. Eklund
+
 The following references have been invaluable:
 
 * [MSDN DirectWrite overview](https://docs.microsoft.com/en-us/windows/desktop/directwrite/introducing-directwrite#accessing-the-font-system)
@@ -272,3 +275,4 @@ We'd like to acknowledge the contributions of:
 * Evan Wallace, Biru, Leah Cassidy, Katie Gregorio, Morgan Kennedy, and Noah Levin of Figma who have patiently enumerated the needs of their ambitious web product.
 * Tab Atkins and the CSS Working Group who have provided usable base-classes which only need slight extension to enable these cases
 * Dominik Röttsches and Igor Kopylov for their thoughtful feedback
+* Lastly, we would like to express our gratitude to former editor Emil A. Eklund, who passed away in 2020. Emil was instrumental in getting this proposal underway, providing technical guidance, and championing the needs of users and developers

--- a/index.bs
+++ b/index.bs
@@ -10,6 +10,7 @@ Abstract: This specification documents web browser support for allowing users to
 Editor: Alex Russell, Google Inc. https://google.com, slightlyoff@google.com
 Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com
 Editor: Olivier Yiptong, Google Inc. https://google.com, oyiptong@google.com
+Former Editor: Emil A. Eklund
 Assume Explicit For: yes
 Markup Shorthands: markdown yes, css yes
 Complain About: accidental-2119 yes, missing-example-ids yes
@@ -555,17 +556,13 @@ There are services which create fonts based on handwriting samples. If these fon
 # Acknowledgements # {#acknowledgements}
 <!-- ============================================================ -->
 
-Former editors:
-
-* Emil A. Eklund
-
 We'd like to acknowledge the contributions of:
 
 * Daniel Nishi, Owen Campbell-Moore, and Mike Tsao who helped pioneer the previous local font access proposal.
 * Evan Wallace, Biru, Leah Cassidy, Katie Gregorio, Morgan Kennedy, and Noah Levin of Figma who have patiently enumerated the needs of their ambitious web product.
 * Tab Atkins and the CSS Working Group who have provided usable base-classes which only need slight extension to enable these cases
 * Dominik Röttsches and Igor Kopylov for their thoughtful feedback
-* Lastly, we would like to express our gratitude to former editor Emil A. Eklund, who passed away in 2020. Emil was instrumental in getting this proposal underway, providing technical guidance, and championing the needs of users and developers
+* We would like to express our gratitude to former editor Emil A. Eklund, who passed away in 2020. Emil was instrumental in getting this proposal underway, providing technical guidance, and championing the needs of users and developers
 
 Special thanks (again!) to Tab Atkins, Jr. for creating and maintaining [Bikeshed](https://github.com/tabatkins/bikeshed), the specification authoring tool used to create this document.
 

--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,6 @@ Group: WICG
 ED: https://wicg.github.io/local-font-access/
 Repository: WICG/local-font-access
 Abstract: This specification documents web browser support for allowing users to grant web sites access to the full set of available system fonts for enumeration, and access to the raw table data of fonts, allowing for more detailed custom text rendering.
-Editor: Emil A. Eklund, Google Inc. https://google.com, eae@google.com
 Editor: Alex Russell, Google Inc. https://google.com, slightlyoff@google.com
 Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com
 Editor: Olivier Yiptong, Google Inc. https://google.com, oyiptong@google.com
@@ -556,10 +555,17 @@ There are services which create fonts based on handwriting samples. If these fon
 # Acknowledgements # {#acknowledgements}
 <!-- ============================================================ -->
 
+Former editors:
+
+* Emil A. Eklund
+
 We'd like to acknowledge the contributions of:
 
 * Daniel Nishi, Owen Campbell-Moore, and Mike Tsao who helped pioneer the previous local font access proposal.
 * Evan Wallace, Biru, Leah Cassidy, Katie Gregorio, Morgan Kennedy, and Noah Levin of Figma who have patiently enumerated the needs of their ambitious web product.
+* Tab Atkins and the CSS Working Group who have provided usable base-classes which only need slight extension to enable these cases
+* Dominik Röttsches and Igor Kopylov for their thoughtful feedback
+* Lastly, we would like to express our gratitude to former editor Emil A. Eklund, who passed away in 2020. Emil was instrumental in getting this proposal underway, providing technical guidance, and championing the needs of users and developers
 
 Special thanks (again!) to Tab Atkins, Jr. for creating and maintaining [Bikeshed](https://github.com/tabatkins/bikeshed), the specification authoring tool used to create this document.
 


### PR DESCRIPTION
Sadly, Emil passed away.

This change adds a former editor section for Emil.