### PR TITLE
Demonstrate how to use local fonts for styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Advanced creative tools may wish to use CSS to style text using all available lo
     for await (const metadata of navigator.fonts.query()) {
       const option = document.createElement("option");
       option.text = metadata.fullName;
+      // postscriptName works well as an identifier of sorts.
+      // It is unique as returned by the API, the OpenType spec expects
+      // it to be in ASCII, and it can be used by @font-face src: local
+      // matching to be used to style elements.
       option.value = metadata.postscriptName;
       fontSelect.append(option);
     }

--- a/README.md
+++ b/README.md
@@ -115,18 +115,27 @@ Font enumeration can help by enabling:
 Advanced creative tools may wish to use CSS to style text using all available local fonts. In this case, getting access to the local font name can allow the user to select from a richer set of choices:
 
 ```js
-const fontSelect = document.createElement("select");
-fontSelect.onchange = e => {
-  console.log("selected:", fontSelect.value);
-  // Use the selected font to style something here.
-};
-
-document.body.appendChild(fontSelect);
-
 (async () => { // Async block
   const status = await navigator.permissions.query({ name: "font-access" });
   if (status.state === "denied")
     throw new Error("Cannot continue to style with local fonts");
+
+  const exampleText = document.createElement("p");
+  exampleText.id = "exampleText";
+  exampleText.innerText = "The quick brown fox jumps over the lazy dog";
+  exampleText.style.fontFamily = "dynamic-font";
+
+  const textStyle = document.createElement("style");
+  const fontSelect = document.createElement("select");
+  fontSelect.onchange = e => {
+    console.log("selected:", fontSelect.value);
+    // An example of styling using @font-face src: local matching.
+    textStyle.textContent = `
+      @font-face {
+        font-family: "dynamic-font";
+        src: local("${postscriptName}");
+      }`;
+  };
 
   try {
     // May prompt the user:
@@ -136,10 +145,14 @@ document.body.appendChild(fontSelect);
       option.value = metadata.postscriptName;
       fontSelect.append(option);
     }
+    document.body.appendChild(textStyle);
+    document.body.appendChild(exampleText);
+    document.body.appendChild(fontSelect);
   } catch(e) {
     // Handle error. It could be a permission error.
     throw new Error(e);
   }
+}
 })();
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -157,18 +157,28 @@ Advanced creative tools may wish to use CSS to style text using all available lo
 The following code populates a drop-down selection form element with the available local fonts, and could be used as part of the user interface for an editing application.
 
 ```js
-const fontSelect = document.createElement("select");
-fontSelect.onchange = e => {
-  console.log("selected:", fontSelect.value);
-  // Use the selected font to style something here.
-};
-
-document.body.appendChild(fontSelect);
-
 (async () => { // Async block
   const status = await navigator.permissions.query({ name: "font-access" });
   if (status.state === "denied")
     throw new Error("Cannot continue to style with local fonts");
+
+  const exampleText = document.createElement("p");
+  exampleText.id = "exampleText";
+  exampleText.innerText = "The quick brown fox jumps over the lazy dog";
+  exampleText.style.fontFamily = "dynamic-font";
+
+  const textStyle = document.createElement("style");
+  const fontSelect = document.createElement("select");
+  fontSelect.onchange = e => {
+    console.log("selected:", fontSelect.value);
+    // An example of styling using @font-face src: local matching.
+    changeFontStyle(fontSelect.value);
+    textStyle.textContent = `
+      @font-face {
+        font-family: "dynamic-font";
+        src: local("${postscriptName}");
+      }`;
+  };
 
   try {
     // May prompt the user:
@@ -178,6 +188,9 @@ document.body.appendChild(fontSelect);
       option.value = metadata.postscriptName;
       fontSelect.append(option);
     }
+    document.body.appendChild(textStyle);
+    document.body.appendChild(exampleText);
+    document.body.appendChild(fontSelect);
   } catch(e) {
     // Handle error. It could be a permission error.
     throw new Error(e);

--- a/index.bs
+++ b/index.bs
@@ -173,11 +173,11 @@ The following code populates a drop-down selection form element with the availab
     console.log("selected:", fontSelect.value);
     // An example of styling using @font-face src: local matching.
     changeFontStyle(fontSelect.value);
-    textStyle.textContent = `
+    textStyle.textContent = \`
       @font-face {
         font-family: "dynamic-font";
         src: local("${postscriptName}");
-      }`;
+      }\`;
   };
 
   try {
@@ -185,6 +185,10 @@ The following code populates a drop-down selection form element with the availab
     for await (const metadata of navigator.fonts.query()) {
       const option = document.createElement("option");
       option.text = metadata.fullName;
+      // postscriptName works well as an identifier of sorts.
+      // It is unique as returned by the API, the OpenType spec expects
+      // it to be in ASCII, and it can be used by @font-face src: local
+      // matching to be used to style elements.
       option.value = metadata.postscriptName;
       fontSelect.append(option);
     }
@@ -443,7 +447,7 @@ A {{FontMetadata}} provides details about a font face. Each {{FontMetadata}} has
 <div class="domintro note">
 
     : |metadata| . {{FontMetadata/postscriptName}}
-    :: The PostScript name for the font. Example: "`Arial-Bold`"
+    :: The PostScript name for the font. Example: "`Arial-Bold`". The OpenType spec expects this to be encoded in a subset of ASCII and is unique for |metadata|
 
     : |metadata| . {{FontMetadata/fullName}}
     :: The full font name, including family subfamily names. Example: "`Arial Bold`"


### PR DESCRIPTION
Fleshed out the example a bit to show how `@font-face src: local` API can be used to load local fonts for styling.

Fixes #52