### PR TITLE
Include font version as fingerprintable surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,12 @@ Other issues that feedback is needed on:
 
 * The `local-fonts` permission appears to provide a highly fingerprintable surface. However, UAs are free to return anything they like.  For example, the Tor Browser or Brave may choose to only provide a set of default fonts built into the browser. Similarly, UAs are not required to provide table data exactly as it appears on disk. Browsers, e.g., may choose to only provide access to table data after sanitization via [OTS](https://github.com/khaledhosny/ots) and would fail to reflect certain tables entirely.
 
+* Another fingerprinting vector could be the font version. Providing access to the raw font data could provide further bits of entropy, due to developers being able to discern between users having certain versions of a given font file.
+
 * Some users (mostly in big organizations) have custom fonts installed on their system.  Listing these could provide highly identifying information about the user's company.
 
 * Wherever possible, these APIs are designed to only expose exactly the information needed to enable the mentioned use cases.  System APIs may produce a list of installed fonts not in a random or a sorted order, but in the order of font installation.  Returning exactly the list of installed fonts given by such a system API can expose additional entropy bits, and use cases we want to enable aren't assisted by retaining this ordering.  As a result, this API requires that the returned data be sorted before being returned.
+
 
 ## Considered alternatives
 

--- a/index.bs
+++ b/index.bs
@@ -537,11 +537,12 @@ There are no known security impacts of this feature.
 ## Fingerprinting ## {#privacy-fingerprinting}
 <!-- ============================================================ -->
 
-The font list includes:
+The font metadata includes:
 
 * Fonts included in the operating system distribution.
 * Fonts installed by particular applications installed on the system, for example office suites.
 * Fonts directly installed by the system administrator and/or end user.
+* The version of the font installed on the system, obtained via the font data.
 
 This provides several "bits of entropy" to distinguish users.
 


### PR DESCRIPTION
As part addressing some review comments in #48, this adds some language explaining that the font version is a possible fingerprinting surface.

Fixes #25 