### PR TITLE
Additional FontMetadata properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A successful API should:
  * Shield applications from unnecessary complexity by requiring that browser implementations produce valid SFNT data in the returned data
  * Restrict access to local font data to Secure Contexts and to only the top-most frame by default via the [Permissions Policy](https://w3c.github.io/webappsec-permissions-policy/) spec
  * Sort any result list by font name to reduce possible fingerprinting entropy bits; e.g. .query() returns an iterable which will be [sorted](https://infra.spec.whatwg.org/#list-sort-in-ascending-order) by given font names
+ * Provide access to commonly used properties of fonts (for example, metrics used in CSS selectors, or when building font selection UI) without requiring parsing every font.
 
 #### Possible/Future Goals
 
@@ -124,10 +125,13 @@ showLocalFontsButton.onclick = async function() {
 
     array.forEach(metadata => {
       console.log(metadata.postscriptName);
-      console.log(metadata.fullName);
-      console.log(metadata.family);
-      console.log(metadata.family);
-      console.log(metadata.style);
+      console.log(` full name: ${metadata.fullName}`);
+      console.log(` family: ${metadata.family}`);
+      console.log(` style: ${metadata.style}`);
+
+      console.log(` italic: ${metadata.italic}`);
+      console.log(` stretch: ${metadata.stretch}`);
+      console.log(` weight: ${metadata.weight}`);
     });
    } catch(e) {
     // Handle error, e.g. user cancelled the operation.
@@ -248,6 +252,30 @@ includeLocalFontsButton.onclick = async function() {
 
     // Was persistent access granted?
     console.log('Expect granted: ' + (await navigator.permission.query('font-access')).state);
+
+  } catch(e) {
+    // Handle error. It could be a permission error.
+    console.warn(`Local font access not available: ${e.message}`);
+  }
+};
+```
+
+
+### Requesting specific fonts
+
+In some cases, a web application may wish to request access to specific fonts. For example, it may be presenting previously authored content that embeds font names. The `query()` call takes a `select` option that scopes the request to fonts identified by PostScript names. Only matching fonts will be returned.
+
+User agents may provide a different user interface to support this. For example, if the fingerprinting risk is deemed minimal, the request may be satisfied without prompting the user for permission. Alternately, a picker could be shown with only the requested fonts included.
+
+```js
+// User activation is required.
+requestFontsButton.onclick = async function() {
+  try {
+    const array = await navigator.fonts.query({select: ['Verdana', 'Verdana-Bold', 'Verdana-Italic']});
+
+    array.forEach(metadata => {
+      console.log(`Access granted for ${metadata.postscriptName}`);
+    });
 
   } catch(e) {
     // Handle error. It could be a permission error.

--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,10 @@ spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/
         text: ecma-record; url: #sec-list-and-record-specification-type
 </pre>
 
+<pre class=link-defaults>
+spec:css-fonts-4; type:value; text:italic
+</pre>
+
 <style>
 /* Default ED/WD stylesheets set "both"; not needed for logo floated right */
 div.head h1 { clear: left; }
@@ -117,7 +121,7 @@ The ability to uniquely identify a specific font in the case of conflicting name
 The API allows script to enumerate local fonts, including properties about each font.
 
 <aside class=example id=example-async-query>
-The following code queries the available local fonts, and logs details about each to the console.
+The following code queries the available local fonts, and logs the names and metrics of each to the console.
 
 ```js
 showLocalFontsButton.onclick = async function() {
@@ -130,10 +134,13 @@ showLocalFontsButton.onclick = async function() {
 
     array.forEach(metadata => {
       console.log(metadata.postscriptName);
-      console.log(metadata.fullName);
-      console.log(metadata.family);
-      console.log(metadata.family);
-      console.log(metadata.style);
+      console.log(` full name: ${metadata.fullName}`);
+      console.log(` family: ${metadata.family}`);
+      console.log(` style: ${metadata.style}`);
+
+      console.log(` italic: ${metadata.italic}`);
+      console.log(` stretch: ${metadata.stretch}`);
+      console.log(` weight: ${metadata.weight}`);
     });
    } catch(e) {
     // Handle error, e.g. user cancelled the operation.
@@ -259,24 +266,23 @@ Parsing font files in more detail, for example enumerating the contained tables,
 </aside>
 
 
-Issue: Add example with {{QueryOptions/select}}.
-
 <!-- ============================================================ -->
-## Persistent access ## {#example-persistent-access}
+## Requesting specific fonts ## {#example-requesting-specific-fonts}
 <!-- ============================================================ -->
 
-In the above examples, the `query()` call allows the user agent to prompt the user for access to some or all local fonts at the time of the call. For example, this could show a font picker interface allowing selection of fonts.
+In some cases, a web application may wish to request access to specific fonts. For example, it may be presenting previously authored content that embeds font names. The `query()` call takes a `select` option that scopes the request to fonts identified by PostScript names. Only matching fonts will be returned.
 
-Other scenarios would benefit from access to local fonts on an ongoing basis. For example, a web application could offer font selection UI showing both fonts provided by the web application's server as well as local fonts. Calling `query()` with `{persistentAccess:true}` will request a permission (`"font-access"`). If that permission is granted, then subsequent calls to `query()` with that option not prompt the user.
+User agents may provide a different user interface to support this. For example, if the fingerprinting risk is deemed minimal, the request may be satisfied without prompting the user for permission. Alternately, a picker could be shown with only the requested fonts included.
 
 ```js
 // User activation is required.
-includeLocalFontsButton.onclick = async function() {
+requestFontsButton.onclick = async function() {
   try {
-    const array = await navigator.fonts.query({persistentAccess: true});
+    const array = await navigator.fonts.query({select: ['Verdana', 'Verdana-Bold', 'Verdana-Italic']});
 
-    // Was persistent access granted?
-    console.log('Expect granted: ' + (await navigator.permission.query('font-access')).state);
+    array.forEach(metadata => {
+      console.log(`Access granted for ${metadata.postscriptName}`);
+    });
 
   } catch(e) {
     // Handle error. It could be a permission error.
@@ -342,6 +348,39 @@ Issue: What if there is no matching |id| or |tag|? Empty string? Where does fall
 </div>
 
 The <dfn>current language</dfn> is the BCP 47 language tag returned by the {{NavigatorLanguage}} mixin's {{NavigatorLanguage/language}} propertyy. [[BCP47]]
+
+
+<!-- ============================================================ -->
+## Metrics Table ## {#concept-metrics-table}
+<!-- ============================================================ -->
+
+A [=/font representation=] has a <dfn for="font representation">metrics table</dfn>, which is the [=/font table=] in its [=font representation/table list=] with [=font table/tag=] \``OS/2`\`. The table is a mapping from a string to a value.
+
+A [=/font representation=]'s <dfn for="font representation">italic property</dfn> is true if its [=font representation/metrics table=] has a \``fcSelection`\` entry (a 16-bit unsigned number), and if bit 0 of the entry's value is 1, or false otherwise.
+
+A [=/font representation=]'s <dfn for="font representation">stretch property</dfn> is the value of its [=font representation/metrics table=]'s \``usWidthClass`\` entry (a 16-bit unsigned number) if present, with the value mapped according to the following table, or 1.00 (the default) otherwise:
+
+<table class=data>
+<thead>
+<tr><th>\``usWidthClass`\`</th><th>[=font representation/stretch property=]</th><th>common name</th></tr>
+</thead>
+<tbody>
+<tr><td>1</td><td>0.50</td><td>ultra-condensed</td></tr>
+<tr><td>2</td><td>0.625</td><td>extra-condensed</td></tr>
+<tr><td>3</td><td>0.75</td><td>condensed</td></tr>
+<tr><td>4</td><td>0.825</td><td>semi-condensed</td></tr>
+<tr><td>5</td><td>1.00</td><td>normal</td></tr>
+<tr><td>6</td><td>1.125</td><td>semi-expanded</td></tr>
+<tr><td>7</td><td>1.25</td><td>expanded</td></tr>
+<tr><td>8</td><td>1.50</td><td>extra-expanded</td></tr>
+<tr><td>9</td><td>2.00</td><td>ultra-expanded</td></tr>
+</tbody>
+</table>
+
+A [=/font representation=]'s <dfn for="font representation">weight property</dfn> is the value of its [=font representation/metrics table=]'s \``usWeightClass`\` entry (a 16-bit unsigned number, in the range 1 to 1000) if present, or 400 (the default) otherwise.
+
+Issue: Give wiggle room for other font definitions/APIs to provide values here. Maybe something like "In OpenType font definitions, the foo property is given by .... In other font definitions, an equivalent value should be inferred."
+
 
 <!-- ============================================================ -->
 # Local font access permission # {#permission}
@@ -454,10 +493,19 @@ A {{FontMetadata}} provides details about a font face. Each {{FontMetadata}} has
     :: The full font name, including family subfamily names. Example: "`Arial Bold`"
 
     : |metadata| . {{FontMetadata/family}}
-    :: The font family name. Example: "`Arial`"
+    :: The font family name. This corresponds with the CSS 'font-family' property. Example: "`Arial`"
 
     : |metadata| . {{FontMetadata/style}}
     :: The font style (or subfamily) name. Example: "`Regular`", "`Bold Italic`"
+
+    : |metadata| . {{FontMetadata/italic}}
+    :: Returns true if this font is labeled as italic or oblique, false otherwise. This corresponds with the CSS 'font-style' property's <a value for=font-style>italic</a> value.
+
+    : |metadata| . {{FontMetadata/stretch}}
+    :: Returns the stretch or width of the font, as a number from 0.5 (50%) to 2.0 (200%), with a default of 1.0 (100%). This corresponds with the CSS 'font-stretch' property numeric value.
+
+    : |metadata| . {{FontMetadata/style}}
+    :: Returns the weight of the font, as a number from 1 to 1000, with a default of 400. This corresponds with the CSS 'font-weight' property numeric value.
 
 </div>
 
@@ -467,10 +515,16 @@ A {{FontMetadata}} provides details about a font face. Each {{FontMetadata}} has
 interface FontMetadata {
   Promise<Blob> blob();
 
+  // Names
   readonly attribute USVString postscriptName;
   readonly attribute USVString fullName;
   readonly attribute USVString family;
   readonly attribute USVString style;
+
+  // Metrics
+  readonly attribute boolean italic;
+  readonly attribute float stretch;
+  readonly attribute float weight;
 };
 </xmp>
 
@@ -483,6 +537,12 @@ The <dfn attribute>fullName</dfn> getter steps are to return [=/this=]'s associa
 The <dfn attribute>family</dfn> getter steps are to return [=/this=]'s associated [=/font representation=]'s [=font representation/name string=] 1 for the [=/current language=].
 
 The <dfn attribute>style</dfn> getter steps are to return [=/this=]'s associated [=/font representation=]'s [=font representation/name string=] 2 for the [=/current language=].
+
+The <dfn attribute>italic</dfn> getter steps are to return [=/this=]'s associated [=/font representation=]'s [=font representation/italic property=].
+
+The <dfn attribute>stretch</dfn> getter steps are to return [=/this=]'s associated [=/font representation=]'s [=font representation/stretch property=].
+
+The <dfn attribute>weight</dfn> getter steps are to return [=/this=]'s associated [=/font representation=]'s [=font representation/weight property=].
 
 </div>
 


### PR DESCRIPTION
* defines the metrics table
* adds the new FontMetadata properties (italic, stretch, weight)
* gives an example for the query({select}) option
