### PR TITLE
Make OpenType representation properties non-normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -644,10 +644,11 @@ We'd like to acknowledge the contributions of:
 Special thanks (again!) to Tab Atkins, Jr. for creating and maintaining [Bikeshed](https://github.com/tabatkins/bikeshed), the specification authoring tool used to create this document.
 
 And thanks to
+Anne van Kesteren,
 Chase Phillips,
 Domenic Denicola,
 Dominik Röttsches,
-Igor Kopylov, and
-Jake Archibald
-
+Igor Kopylov,
+Jake Archibald, and
+Jeffrey Yasskin
 for suggestions, reviews, and other feedback.

--- a/index.bs
+++ b/index.bs
@@ -297,7 +297,7 @@ The [=/font representation=]'s [=font representation/data bytes=] are generally 
 </div>
 
 <aside class=note>
-As an example, the [=/font representation=] of an OpenType [[!OPENTYPE]] font would be as follows:
+This specification doesn't precisely define the values of the above fields for any particular font format, so that differences between operating systems don't make UAs non-compliant. However, for an OpenType [[!OPENTYPE]] font the following values would be sensible:
 * The [=font representation/data bytes=] are the SFNT [[!SFNT]] serialization of the font.
 * The [=font representation/PostScript name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 6; if multiple localizations are available, the US English version is used if provided, or the first localization otherwise.
 * The [=font representation/full name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 4; if multiple localizations are available, the [=/user language=] version is used if provided, or the first localization otherwise.

--- a/index.bs
+++ b/index.bs
@@ -283,6 +283,12 @@ A <dfn>font representation</dfn> is some concrete representation of a font. Exam
 <div dfn-for="font representation">
 
 * The <dfn>data bytes</dfn>, which is a [=/byte sequence=] containing a serialization of the font.
+
+<aside class=note>
+The [=/font representation=]'s [=font representation/data bytes=] are generally expected to be the exact byte-by-byte representation of font files on the user's filesystem. UAs aren't expected to normalize the font data, so font representations would not vary across user agents for a given user on a particular OS. The lack of normalization supports the goal of enabling web applications that perform text rendering for content creation with the full fidelity of the font.
+</aside>
+
+
 * The <dfn>PostScript name</dfn>, which is a {{DOMString}}. This is commonly used as a unique identifier for the font during font loading, e.g. "Optima-Bold".
 * The <dfn>full name</dfn>, which is a {{DOMString}}. This is usually a human-readable name used to identify the font, e.g. "Optima Bold".
 * The <dfn>family name</dfn>, which is a {{DOMString}}. This defines a set of fonts that vary among attributes such as weight and slope, e.g. "Optima"
@@ -291,7 +297,14 @@ A <dfn>font representation</dfn> is some concrete representation of a font. Exam
 </div>
 
 <aside class=note>
-The [=/font representation=]'s [=font representation/data bytes=] are generally expected to be the exact byte-by-byte representation of font files on the user's filesystem. UAs aren't expected to normalize the font data, so font representations would not vary across user agents for a given user on a particular OS. The lack of normalization supports the goal of enabling web applications that perform text rendering for content creation with the full fidelity of the font.
+As an example, the [=/font representation=] of an OpenType [[!OPENTYPE]] font would be as follows:
+* The [=font representation/data bytes=] are the SFNT [[!SFNT]] serialization of the font.
+* The [=font representation/PostScript name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 6; if multiple localizations are available, the US English version is used if provided, or the first localization otherwise.
+* The [=font representation/full name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 4; if multiple localizations are available, the [=/user language=] version is used if provided, or the first localization otherwise.
+* The [=font representation/family name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 1; if multiple localizations are available, the [=/user language=] version is used if provided, or the first localization otherwise.
+* The [=font representation/style name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 2; if multiple localizations are available, the [=/user language=] version is used if provided, or the first localization otherwise.
+
+These name properties are exposed to align with property usage in [[CSS-FONTS-4]], e.g. ''@font-face'', 'font-family', and so on. The [=font representation/PostScript name=] can be used as a unique key, for example when specifying a font when creating content or matching fonts against existing content. The [=font representation/full name=] or [=font representation/family name=] can be used for user-visible font selection UI, and the [=font representation/style name=] can be used to provide more specific selections.
 </aside>
 
 A <dfn>valid PostScript name</dfn> is a [=/scalar value string=] with [=string/length=] less than 64 and consisting only of characters in the range U+0021 (!) to U+007E (~) except for the 10 code units
@@ -308,17 +321,6 @@ U+0025 (%).
 
 <aside class=note>
 This is intended to match the requirements for <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids">nameID = 6</a> in [[!OPENTYPE]].
-</aside>
-
-Defined in terms of OpenType [[!OPENTYPE]] font data:
-* The [=font representation/data bytes=] are the SFNT [[!SFNT]] serialization of the font.
-* The [=font representation/PostScript name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 6; if multiple localizations are available, the US English version must be used if provided, or the first localization otherwise.
-* The [=font representation/full name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 4; if multiple localizations are available, the [=/user language=] version must be used if provided, or the first localization otherwise.
-* The [=font representation/family name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 1; if multiple localizations are available, the [=/user language=] version must be used if provided, or the first localization otherwise.
-* The [=font representation/style name=] is found in the font's <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/name">name table</a>, in the name record with nameID = 2; if multiple localizations are available, the [=/user language=] version must be used if provided, or the first localization otherwise.
-
-<aside class=note>
-These name properties are exposed to align with property usage in [[CSS-FONTS-4]], e.g. ''@font-face'', 'font-family', and so on. The [=font representation/PostScript name=] can be used as a unique key, for example when specifying a font when creating content or matching fonts against existing content. The [=font representation/full name=] or [=font representation/family name=] can be used for user-visible font selection UI, and the [=font representation/style name=] can be used to provide more specific selections.
 </aside>
 
 


### PR DESCRIPTION
Per suggestion in https://github.com/mozilla/standards-positions/issues/401#issuecomment-1115057239 make the OpenType definitions of font representation properties non-normative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/local-font-access/pull/89.html" title="Last updated on May 2, 2022, 8:07 PM UTC (a060fec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/local-font-access/89/b30f6bb...a060fec.html" title="Last updated on May 2, 2022, 8:07 PM UTC (a060fec)">Diff</a>