### PR TITLE
Use allowMultiple in prompt

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -473,7 +473,7 @@ The <dfn method for=Window>queryLocalFonts(|options|)</dfn> method steps are:
         1. Assert: |postscriptName| is a [=/valid PostScript name=].
         1. If |options|[{{QueryOptions/"postscriptNames"}}] [=map/exists=] and |options|[{{QueryOptions/"postscriptNames"}}] does not [=list/contain=] |postscriptName|, then [=iteration/continue=].
         1. [=list/Append=] a new {{FontData}} instance associated with |representation| to |selectable fonts|.
-    1. [=/Prompt the user to choose=] one or more items from |selectable fonts|, with |descriptor|, and let |result| be the result.
+    1. [=/Prompt the user to choose=] one or more items from |selectable fonts|, with |descriptor| and <var ignore>allowMultiple</var> set to true, and let |result| be the result.
         User agents may present a yes/no choice instead of a list of choices, and in that case they should set |result| to |selectable fonts|.
     1. If |result| is {{PermissionState/"denied"}}, then [=/reject=] |promise| with a "{{NotAllowedError}}" {{DOMException}}, and abort these steps.
     1. Sort |result| in [=list/sort in ascending order|ascending order=] by using {{FontData/postscriptName}} as the sort key and store the result as |result|.


### PR DESCRIPTION
As suggested by @miketaylr in #91 

I couldn't determine the best Bikeshed syntax for this; I don't think the argument is defined in a way that gets exported? Anyway, suggestions welcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/local-font-access/pull/98.html" title="Last updated on Jul 15, 2022, 7:44 PM UTC (fd80170)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/local-font-access/98/4168e93...fd80170.html" title="Last updated on Jul 15, 2022, 7:44 PM UTC (fd80170)">Diff</a>